### PR TITLE
Add options for detection of mobile devices, and small screens

### DIFF
--- a/octoprint_widescreen/__init__.py
+++ b/octoprint_widescreen/__init__.py
@@ -11,7 +11,10 @@ class WidescreenPlugin(octoprint.plugin.SettingsPlugin,
 
 	def get_settings_defaults(self):
 		return dict(
-			right_sidebar_items = []
+			right_sidebar_items = [],
+			use_resolution=False,
+			resolution_threshold=480,
+			use_useragent=False,
 		)
 
 	##~~ AssetPlugin mixin

--- a/octoprint_widescreen/static/css/widescreen.css
+++ b/octoprint_widescreen/static/css/widescreen.css
@@ -2,3 +2,9 @@
     right: 0;
     left: auto;
 }
+
+#settings_plugin_widescreen .border-right {
+    border-right: darkgray;
+    border-right-style: solid;
+    border-right-width: 1px;
+}

--- a/octoprint_widescreen/static/js/widescreen.js
+++ b/octoprint_widescreen/static/js/widescreen.js
@@ -15,27 +15,57 @@ $(function() {
 			return
 		}
 
+        self.should_use_resolution = ko.observable()
+        self.resolution_threshold = ko.observable()
+        self.should_use_useragent = ko.observable()
+
+        self.should_show = true
+
+        self.should_show_widescreen = function() {
+		    if (self.should_use_useragent()) {
+                if (/Mobi/.test(navigator.userAgent)) {
+                    // mobile useragent
+                    self.should_show = false;
+                }
+            }
+		    if (self.should_use_resolution()) {
+		        if (screen.width <= parseInt(self.resolution_threshold(), 10)){
+		            // small screen
+		            self.should_show = false;
+                }
+            }
+		    console.log("Should show widescreen?: " + self.should_show)
+        }
+
 		self.right_sidebar_items = ko.observableArray([]);
 		self.available_sidebar_items = ko.observableArray([]);
 
 
 		self.onBeforeBinding = function() {
+		    self.should_use_resolution(self.settingsViewModel.settings.plugins.widescreen.use_resolution());
+            self.resolution_threshold(self.settingsViewModel.settings.plugins.widescreen.resolution_threshold());
+            self.should_use_useragent(self.settingsViewModel.settings.plugins.widescreen.use_useragent());
 			self.right_sidebar_items(self.settingsViewModel.settings.plugins.widescreen.right_sidebar_items());
 		}
 
 		self.onSettingsBeforeSave = function () {
+		    self.settingsViewModel.settings.plugins.widescreen.use_resolution(self.should_use_resolution());
+		    self.settingsViewModel.settings.plugins.widescreen.resolution_threshold(self.resolution_threshold());
+		    self.settingsViewModel.settings.plugins.widescreen.use_useragent(self.should_use_useragent());
 			self.settingsViewModel.settings.plugins.widescreen.right_sidebar_items(self.right_sidebar_items());
 		}
 
 		self.onEventSettingsUpdated = function (payload) {
-			// move panels to right sidebar
-			ko.utils.arrayForEach(self.right_sidebar_items(), function(item) {
-				$('#'+item+'_wrapper').appendTo('#right_sidebar');
-			});
-			// move panels to left sidebar
-			ko.utils.arrayForEach(self.available_sidebar_items(), function(item) {
-				$('#'+item+'_wrapper').appendTo('#sidebar');
-			});
+		    if (self.should_show) {
+                // move panels to right sidebar
+                ko.utils.arrayForEach(self.right_sidebar_items(), function (item) {
+                    $('#' + item + '_wrapper').appendTo('#right_sidebar');
+                });
+                // move panels to left sidebar
+                ko.utils.arrayForEach(self.available_sidebar_items(), function (item) {
+                    $('#' + item + '_wrapper').appendTo('#sidebar');
+                });
+            }
 		}
 
 		self.onAfterBinding = function(){
@@ -48,32 +78,38 @@ $(function() {
 		}
 
 		self.onAllBound = function(){
-			// navbar adjustments
-			$('#navbar > div.navbar-inner > div.container').css({'width':'100%'});
-			$('#navbar > div.navbar-inner').css({'padding-left':'20px'});
+		    self.should_show_widescreen()
+		    if (self.should_show) {
+                // navbar adjustments
+                $('#navbar > div.navbar-inner > div.container').css({'width': '100%'});
+                $('#navbar > div.navbar-inner').css({'padding-left': '20px'});
 
-			// main content adjustments
-			$('div.container.octoprint-container').addClass('row-fluid');
-			$('div.container.octoprint-container.row-fluid > div.row').css({'margin-left':'20px','padding-right':'20px'});
+                // main content adjustments
+                $('div.container.octoprint-container').addClass('row-fluid');
+                $('div.container.octoprint-container.row-fluid > div.row').css({
+                    'margin-left': '20px',
+                    'padding-right': '20px'
+                });
 
-			// sidebar adjustments
-			$('div.container.octoprint-container > div.row > div.accordion.span4:first').removeClass('span4').addClass('span3');
-			// $('#files div.row-fluid.upload-buttons > span.btn.btn-primary.fileinput-button.span6:nth-child(2) > span').text('Upload SD');
+                // sidebar adjustments
+                $('div.container.octoprint-container > div.row > div.accordion.span4:first').removeClass('span4').addClass('span3');
+                // $('#files div.row-fluid.upload-buttons > span.btn.btn-primary.fileinput-button.span6:nth-child(2) > span').text('Upload SD');
 
-			// footer adjustments
-			$('ul#footer_version').css({'padding-left':'20px'});
-			$('ul#footer_links').css({'padding-right':'20px'});
+                // footer adjustments
+                $('ul#footer_version').css({'padding-left': '20px'});
+                $('ul#footer_links').css({'padding-right': '20px'});
 
-			// tabs adjustments
-			$('div.container.octoprint-container > div.row > div.tabbable.span8').removeClass('span8').addClass('span6');
+                // tabs adjustments
+                $('div.container.octoprint-container > div.row > div.tabbable.span8').removeClass('span8').addClass('span6');
 
-			// add new right sidebar
-			$('div.container.octoprint-container > div.row').append('<div class="accordion span3" id="right_sidebar"></div>');
+                // add new right sidebar
+                $('div.container.octoprint-container > div.row').append('<div class="accordion span3" id="right_sidebar"></div>');
 
-			// move panels to right sidebar
-			ko.utils.arrayForEach(self.right_sidebar_items(), function(item) {
-				$('#'+item+'_wrapper').appendTo('#right_sidebar');
-			});
+                // move panels to right sidebar
+                ko.utils.arrayForEach(self.right_sidebar_items(), function (item) {
+                    $('#' + item + '_wrapper').appendTo('#right_sidebar');
+                });
+            }
 		}
 
 		self.add_sidebar_item = function(data) {

--- a/octoprint_widescreen/templates/widescreen_settings.jinja2
+++ b/octoprint_widescreen/templates/widescreen_settings.jinja2
@@ -1,3 +1,43 @@
+<h4>OctoPrint Widescreen</h4>
+<div class="row-fluid" style="margin-top: 10px;">
+    <div class="span12">
+        <div class="alert">
+              <strong>Note:</strong> These settings only take effect when the page is reloaded.
+        </div>
+    </div>
+</div>
+<div class="row-fluid">
+    <div class="span6 border-right">
+        <div class="form-inline">
+            <label class="checkbox inline">
+                <input type="checkbox" data-bind="checked: should_use_useragent"> Detect small screens based on User Agent
+            </label>
+            <div class="help-block">
+                The widescreen will not show on browsers identifying themselves as mobile devices.
+            </div>
+        </div>
+    </div>
+    <div class="span6">
+        <div class="form-inline">
+            <label class="checkbox inline">
+                <input type="checkbox" data-bind="checked: should_use_resolution"> Detect small screens based on resolution
+            </label>
+            <div data-bind="visible: should_use_resolution">
+                <label class="inline">
+                    Resolution threshold:
+                </label>
+                <div class="input-append">
+                    <input type="number" min="0" data-bind="value: resolution_threshold">
+                    <span class="add-on">px</span>
+                </div>
+            </div>
+            <div class="help-block">
+                The widescreen will not show on browsers with screen width below the threshold.
+            </div>
+        </div>
+    </div>
+</div>
+<hr>
 <div class="row-fluid"><small>Drag and drop panels between the left and right sidebars.</small></div>
 <div class="row-fluid">
 	<div class="span6">


### PR DESCRIPTION
🎉  Closes #12 

Adds options for:
* Detecting a mobile browser. Per https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent it looks for `Mobi` in the user agent to determine. Doesn't show widescreen
* Detecting a small screen, based on a configurable threshold. Default is 480px, no idea if this is realistic it just felt like a good number.

UI looks like this (resolution threshold appears if enabled): 
![image](https://user-images.githubusercontent.com/31997505/98742199-eac09e00-23a5-11eb-88bf-71d35f790cc7.png)
